### PR TITLE
fix(install): sh実行時のエラーを解消する

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -42,13 +42,21 @@ if [ ! -f ${SCRIPT_DIR_PATH}/.dictionaries/SKK-JISYO.jawiki ]; then
 fi
 
 # macSKK
-mkdir -p ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Library/Preferences
-cp ${SCRIPT_DIR_PATH}/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Library/Preferences/net.mtgto.inputmethod.macSKK.plist ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Library/Preferences/net.mtgto.inputmethod.macSKK.plist
-mkdir -p ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings
-cp ${SCRIPT_DIR_PATH}/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings/kana-rule.conf ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings/kana-rule.conf
-mkdir -p ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries
-cp ${SCRIPT_DIR_PATH}/.dictionaries/SKK-JISYO.jawiki ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/SKK-JISYO.jawiki
-cp ${SCRIPT_DIR_PATH}/.dictionaries/SKK-JISYO.emoji.utf8 ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/SKK-JISYO.emoji.utf8
+# macOS 14以降、他アプリのコンテナ（~/Library/Containers）はOSに保護されており、
+# ターミナルにアクセス権限がないと Operation not permitted でコピーに失敗する
+MACSKK_SRC_DATA_PATH=${SCRIPT_DIR_PATH}/Library/Containers/net.mtgto.inputmethod.macSKK/Data
+MACSKK_DEST_DATA_PATH=~/Library/Containers/net.mtgto.inputmethod.macSKK/Data
+mkdir -p ${MACSKK_DEST_DATA_PATH}/Library/Preferences 2> /dev/null \
+  && mkdir -p ${MACSKK_DEST_DATA_PATH}/Documents/Settings 2> /dev/null \
+  && mkdir -p ${MACSKK_DEST_DATA_PATH}/Documents/Dictionaries 2> /dev/null \
+  && cp ${MACSKK_SRC_DATA_PATH}/Library/Preferences/net.mtgto.inputmethod.macSKK.plist ${MACSKK_DEST_DATA_PATH}/Library/Preferences/net.mtgto.inputmethod.macSKK.plist 2> /dev/null \
+  && cp ${MACSKK_SRC_DATA_PATH}/Documents/Settings/kana-rule.conf ${MACSKK_DEST_DATA_PATH}/Documents/Settings/kana-rule.conf 2> /dev/null \
+  && cp ${SCRIPT_DIR_PATH}/.dictionaries/SKK-JISYO.jawiki ${MACSKK_DEST_DATA_PATH}/Documents/Dictionaries/SKK-JISYO.jawiki 2> /dev/null \
+  && cp ${SCRIPT_DIR_PATH}/.dictionaries/SKK-JISYO.emoji.utf8 ${MACSKK_DEST_DATA_PATH}/Documents/Dictionaries/SKK-JISYO.emoji.utf8 2> /dev/null
+if [ $? -ne 0 ]; then
+  echo '警告: macSKKの設定のコピーに失敗しました。' 1>&2
+  echo '「システム設定 > プライバシーとセキュリティ > フルディスクアクセス」でターミナルを許可してから、再度実行してください。' 1>&2
+fi
 # AquaSKK
 mkdir -p ~/Library/Application\ Support/AquaSKK
 ln -fns ${SCRIPT_DIR_PATH}/Library/Application\ Support/AquaSKK/kana-rule.conf ~/Library/Application\ Support/AquaSKK/kana-rule.conf
@@ -61,9 +69,11 @@ ln -fns ${SCRIPT_DIR_PATH}/.claude/settings.json ~/.claude/settings.json
 ln -fns ${SCRIPT_DIR_PATH}/.claude/statusline-command.sh ~/.claude/statusline-command.sh
 ln -fns ${SCRIPT_DIR_PATH}/.claude/skills ~/.claude/skills
 
-source ~/.bash_profile
+# NOTE: `source ~/.bash_profile` は実行しない
+# ∵.bash_profileから読み込まれる補完スクリプトはbash専用の記述を含み、
+#   sh（POSIXモードのbash）で読み込むとエラーになるため
 
-if [ "$(uname)" == 'Darwin' ]; then
+if [ "$(uname)" = 'Darwin' ]; then
   # スクリーンショットの撮影時に影を含めない
   defaults write com.apple.screencapture disable-shadow -bool true
 
@@ -86,12 +96,17 @@ if [ "$(uname)" == 'Darwin' ]; then
   # ref: https://docs.brew.sh/Installation
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-  source ~/.bash_profile
+  # Homebrewへのパスを通す
+  # ref: https://docs.brew.sh/Installation
+  if [ "$(uname -m)" = 'arm64' ]; then
+    HOMEBREW_HOME=/opt/homebrew
+  else
+    HOMEBREW_HOME=/usr/local
+  fi
+  eval "$(${HOMEBREW_HOME}/bin/brew shellenv)"
 
   # Homebrewで管理しているパッケージをインストールする
   # ref: https://tech.gootablog.com/article/homebrew-brewfile/
   brew bundle
-
-  source ~/.bash_profile
 fi
 


### PR DESCRIPTION
## 概要

`sh Install.sh` の実行時に発生していた2系統のエラーを解消します。

## 原因

### 1. `cp: cannot create regular file '...net.mtgto.inputmethod.macSKK...': Operation not permitted`

macOS 14以降、他アプリのコンテナ（`~/Library/Containers/<bundle-id>/Data`）はTCC（プライバシー保護機構）で保護されており、ターミナルにアクセス権限がないと書き込めません。ファイルのパーミッション自体は問題ないことを確認済みです（`touch` でも同様に失敗）。

これはスクリプト側では回避できないため、コピー失敗時に生の `cp` エラーを4行垂れ流す代わりに、「システム設定 > プライバシーとセキュリティ > フルディスクアクセス」でターミナルを許可するよう促す警告を表示するようにしました。

### 2. `shopt: autocd: invalid shell option name` および `syntax error near unexpected token '<'`

`Install.sh` が `source ~/.bash_profile` を実行しており、`sh`（macOSでは bash 3.2 のPOSIXモード）では以下がエラーになっていました。

- `.bashrc` の `shopt -s autocd`（autocd は bash 4.0 以降の機能）
- 各種補完スクリプトのプロセス置換 `< <(...)`（POSIXモードでは使用不可）

`source ~/.bash_profile` の実質的な目的は Homebrew インストール直後に `brew` へパスを通すことだけなので、`eval "$(brew shellenv)"` の評価に置き換え、それ以外の `source` は削除しました。

あわせて、POSIX準拠でない `[ ... == ... ]` を `[ ... = ... ]` に修正しています。

## 動作確認

- `sh -n Install.sh` で構文チェックが通ることを確認
- macSKKブロックを抽出して実行し、コピー失敗時に警告を表示してスクリプトが継続することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)