### PR TITLE
feat(codex): 設定ファイルを追加する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+#:schema https://learn.chatgpt.com/docs/config-schema.json
+
+# ref: https://learn.chatgpt.com/docs/config-file/config-reference
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+plan_mode_reasoning_effort = "high"
+model_verbosity = "low"
+personality = "pragmatic"
+service_tier = "priority"
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"

--- a/Install.sh
+++ b/Install.sh
@@ -60,6 +60,9 @@ mkdir -p ~/.claude
 ln -fns ${SCRIPT_DIR_PATH}/.claude/settings.json ~/.claude/settings.json
 ln -fns ${SCRIPT_DIR_PATH}/.claude/statusline-command.sh ~/.claude/statusline-command.sh
 ln -fns ${SCRIPT_DIR_PATH}/.claude/skills ~/.claude/skills
+# Codex
+mkdir -p ~/.codex
+ln -fns ${SCRIPT_DIR_PATH}/.codex/config.toml ~/.codex/config.toml
 
 source ~/.bash_profile
 
@@ -94,4 +97,3 @@ if [ "$(uname)" == 'Darwin' ]; then
 
   source ~/.bash_profile
 fi
-

--- a/Uninstall.sh
+++ b/Uninstall.sh
@@ -43,6 +43,8 @@
 /bin/rm ~/.claude/settings.json
 /bin/rm ~/.claude/statusline-command.sh
 /bin/rm -r ~/.claude/skills
+# Codex
+/bin/rm ~/.codex/config.toml
 
 # dpp.vimをアンインストールする
 /bin/rm -r ~/.cache/dpp
@@ -60,4 +62,3 @@ if [ "$(uname)" == 'Darwin' ]; then
   # ref: https://github.com/homebrew/install#uninstall-homebrew
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 fi
-


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- Codexのユーザー設定をdotfilesで管理するようにした
- インストール時にCodex設定ファイルのシンボリックリンクを作成するようにした
- アンインストール時にCodex設定ファイルのシンボリックリンクを削除するようにした

## やってないこと

- なし

## 参考リンク

- https://learn.chatgpt.com/docs/config-file/config-reference
- https://learn.chatgpt.com/docs/config-schema.json