### PR TITLE
fix(nvim): resolve ts_ls root from project files

### DIFF
--- a/.config/nvim/after/lsp/ts_ls.lua
+++ b/.config/nvim/after/lsp/ts_ls.lua
@@ -2,7 +2,12 @@
 return {
   -- ref: https://github.com/neovim/nvim-lspconfig/blob/94d0fec9135719e046903bbbbf8f39e3d3436d4e/lua/lspconfig/configs/ts_ls.lua
   -- ref: https://pawelgrzybek.com/reconcile-two-conflicting-lsp-servers-in-neovim-0-11/#update-neovim-0111-comes-with-workspace_required
-  root_markers = { 'tsconfig.json', 'package.json' },
+  root_dir = function(bufnr, on_dir)
+    local root = vim.fs.root(bufnr, { 'tsconfig.json', 'package.json' })
+    if root then
+      on_dir(root)
+    end
+  end,
   workspace_required = true,
   on_attach = function(client, _)
     client.server_capabilities.documentFormattingProvider = false -- Use Prettier


### PR DESCRIPTION
## 概要

- ts_ls のルートを最寄りの tsconfig.json または package.json から解決
- pnpm モノレポ内でプロジェクトローカルの TypeScript を利用できるように修正

## 背景

nvim-lspconfig の ts_ls はロックファイルを基準にルートを決めるため、pnpm モノレポではワークスペース直下がLSPルートになり、パッケージ配下の TypeScript を検出できない場合がありました。その結果、typescript-language-server にバンドルされた別バージョンの TypeScript が使われ、プロジェクトの typecheck では発生しない診断がNeovim上で表示されていました。

## 確認

- stylua --check .config/nvim/after/lsp/ts_ls.lua
- git diff --check
- 対象ファイルから frontend2/apps/web がルートとして解決されることをヘッドレスNeovimで確認