### PR TITLE
Fix document color buffer filter

### DIFF
--- a/.config/nvim/lua/plugins/config/nvim_lspconfig.lua
+++ b/.config/nvim/lua/plugins/config/nvim_lspconfig.lua
@@ -151,10 +151,11 @@ vim.api.nvim_create_autocmd('LspAttach', {
     --    : https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentColor
     local supports_document_color = client.server_capabilities.colorProvider
     if supports_document_color then
+      local dc_filter = { bufnr = bufnr }
       local dc_opts = { style = '󱓻 ' } -- nf-md-square_rounded
-      vim.lsp.document_color.enable(true, bufnr, dc_opts)
+      vim.lsp.document_color.enable(true, dc_filter, dc_opts)
       vim.keymap.set('n', '<Leader>c', function()
-        vim.lsp.document_color.enable(not vim.lsp.document_color.is_enabled(bufnr), bufnr, dc_opts)
+        vim.lsp.document_color.enable(not vim.lsp.document_color.is_enabled(dc_filter), dc_filter, dc_opts)
       end, bufopts)
     end
     -- }}}


### PR DESCRIPTION
## 概要
- document color のバッファスコープをフィルターテーブルとして渡すように修正
- document color の有効状態の確認と切り替えで同じフィルターを再利用

## 動作確認
- `git diff --check`
- XDG ディレクトリを隔離した Neovim 0.13-dev のヘッドレス環境で、Lua 構文と document color API の呼び出しを確認