### PR TITLE
feat(nvim): install Tailwind CSS language server

### DIFF
--- a/.config/nvim/lua/plugins/config/nvim_lspconfig.lua
+++ b/.config/nvim/lua/plugins/config/nvim_lspconfig.lua
@@ -33,6 +33,7 @@ require('mason-lspconfig').setup {
     'pyright',
     'ruby_lsp',
     'rust_analyzer',
+    'tailwindcss',
     'taplo',
     'terraformls',
     'ts_ls',


### PR DESCRIPTION
## 概要

- mason-lspconfig の ensure_installed に tailwindcss を追加
- Tailwind CSSのクラス補完、ホバー、診断をNeovimで利用可能にする

Masonでは tailwindcss が tailwindcss-language-server パッケージへマッピングされ、既存設定により自動的に有効化されます。

## 確認

- stylua --check .config/nvim/lua/plugins/config/nvim_lspconfig.lua
- git diff --check
- Masonレジストリで tailwindcss と tailwindcss-language-server の対応を確認