### PR TITLE
docs(claude): Qiita記事のAI使用注記を統一

### DIFF
--- a/.claude/skills/write-qiita/SKILL.md
+++ b/.claude/skills/write-qiita/SKILL.md
@@ -63,7 +63,7 @@ ignorePublish: false
 
 ```markdown
 :::note info
-本記事の執筆はClaude Codeを使用しています。
+本記事の執筆にはAIを使用しています。
 :::
 
 ## はじめに

--- a/.claude/skills/write-qiita/assets/template.md
+++ b/.claude/skills/write-qiita/assets/template.md
@@ -12,7 +12,7 @@ slide: false
 ignorePublish: false
 ---
 :::note info
-本記事の執筆はClaude Codeを使用しています。
+本記事の執筆にはAIを使用しています。
 :::
 
 ## はじめに


### PR DESCRIPTION
## 概要

- スキル本体に記載した冒頭のnote本文をClaude CodeからAI表記へ変更
- 記事テンプレートのnote本文を同じ表記へ変更

## 確認

- git diff --check