### PR TITLE
fix(nvim): vimdoc-jaの更新エラーを防止

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -336,6 +336,22 @@ require('lazy').setup({
 
   {
     'vim-jp/vimdoc-ja',
+    -- lazy.nvim runs :helptags after updates, but Neovim rewrites the tracked
+    -- language-specific tag file and then treats the plugin as locally modified.
+    -- Restore the tag file shipped by vimdoc-ja after lazy.nvim regenerates it.
+    build = function(plugin)
+      local result = vim.system({
+        'git',
+        'restore',
+        '--source=HEAD',
+        '--',
+        'doc/tags-ja',
+      }, { cwd = plugin.dir }):wait()
+
+      if result.code ~= 0 then
+        error(result.stderr or 'Failed to restore doc/tags-ja')
+      end
+    end,
     config = function()
       vim.opt.helplang = { 'ja', 'en' }
     end,


### PR DESCRIPTION
## 概要

Lazy update 後に vimdoc-ja の doc/tags-ja がローカル変更扱いとなり、次回の更新が失敗する問題を防止します。

## 原因

lazy.nvim がプラグイン更新後に helptags を実行すると、Neovim が vimdoc-ja に同梱された doc/tags-ja を再生成します。言語別タグファイルは lazy.nvim の自動復元対象外のため、Git の作業ツリーに差分が残っていました。

## 変更内容

- vimdoc-ja の build hook を追加
- helptags 実行後、doc/tags-ja を HEAD の内容へ復元
- 復元失敗時は build エラーとして通知

## 検証

- 隔離した vimdoc-ja の複製で helptags 実行後に差分が生じることを再現
- build hook と同じ処理で doc/tags-ja が復元され、Git 状態がクリーンになることを確認
- git diff --check 成功