### PR TITLE
Claude CodeのskillsをCodexでも使えるようにする

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -69,6 +69,8 @@ ln -fns ${SCRIPT_DIR_PATH}/.claude/settings.json ~/.claude/settings.json
 ln -fns ${SCRIPT_DIR_PATH}/.claude/statusline-command.sh ~/.claude/statusline-command.sh
 ln -fns ${SCRIPT_DIR_PATH}/.claude/skills ~/.claude/skills
 # Codex
+mkdir -p ~/.agents
+ln -fns ${SCRIPT_DIR_PATH}/.claude/skills ~/.agents/skills
 mkdir -p ~/.codex
 mkdir -p ~/.codex/pets
 if [ -L ~/.codex/pets/uhooi-blue ]; then

--- a/Uninstall.sh
+++ b/Uninstall.sh
@@ -44,6 +44,7 @@
 /bin/rm ~/.claude/statusline-command.sh
 /bin/rm -r ~/.claude/skills
 # Codex
+/bin/rm ~/.agents/skills
 /bin/rm ~/.codex/pets/uhooi-blue/pet.json
 /bin/rm ~/.codex/pets/uhooi-blue/spritesheet.webp
 /bin/rmdir ~/.codex/pets/uhooi-blue


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- Claude CodeのskillsをCodexの読み込み先へリンクする処理を追加した
- Codex向けのskillsリンクを削除する処理を追加した

## やってないこと

- なし

## 参考リンク

- https://learn.chatgpt.com/docs/build-skills
