### PR TITLE
herdrの設定を追加

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,7 +1,5 @@
 [ui]
 agent_panel_sort = "spaces"
 
-# Claude Codeの`/rename`で変えたセッション名をサイドバーに表示する
-# ∵セッション名がターミナルタイトルに反映されるため
 [ui.sidebar.agents.rows_by_agent]
 claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,7 @@
+[ui]
+agent_panel_sort = "spaces"
+
+# Claude Codeの`/rename`で変えたセッション名をサイドバーに表示する
+# ∵セッション名がターミナルタイトルに反映されるため
+[ui.sidebar.agents.rows_by_agent]
+claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]

--- a/Install.sh
+++ b/Install.sh
@@ -22,6 +22,10 @@ ln -fns ${SCRIPT_DIR_PATH}/.config/nvim ~/.config/nvim
 ln -fns ${SCRIPT_DIR_PATH}/.config/efm-langserver ~/.config/efm-langserver
 ln -fns ${SCRIPT_DIR_PATH}/.config/ranger ~/.config/ranger
 ln -fns ${SCRIPT_DIR_PATH}/.config/mise ~/.config/mise
+# NOTE: herdrはディレクトリごとリンクしない
+# ∵~/.config/herdrにログやソケット、セッションが作られるため
+mkdir -p ~/.config/herdr
+ln -fns ${SCRIPT_DIR_PATH}/.config/herdr/config.toml ~/.config/herdr/config.toml
 ln -fns ${SCRIPT_DIR_PATH}/.bash_profile ~/.bash_profile
 ln -fns ${SCRIPT_DIR_PATH}/.bashrc ~/.bashrc
 ln -fns ${SCRIPT_DIR_PATH}/.inputrc ~/.inputrc

--- a/Uninstall.sh
+++ b/Uninstall.sh
@@ -18,6 +18,7 @@
 /bin/rm -r ~/.config/efm-langserver
 /bin/rm -r ~/.config/ranger
 /bin/rm -r ~/.config/mise
+/bin/rm ~/.config/herdr/config.toml
 /bin/rm ~/.bash_profile
 /bin/rm ~/.bashrc
 /bin/rm ~/.inputrc


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- herdr の設定ファイルを追加した
- サイドバーの Claude Code の行に、`/rename` で変えたセッション名を表示するようにした
- インストール・アンインストール時に、herdr の設定ファイルのシンボリックリンクを貼る・削除するようにした
  - ディレクトリごとリンクしていないのは、`~/.config/herdr` に herdr がログやソケット、セッションを作るため

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- https://herdr.dev/ja/docs/configuration/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
