### PR TITLE
herdrの通知とテーマを設定

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,5 +1,12 @@
+[theme]
+name = "tokyo-night"
+
 [ui]
 agent_panel_sort = "spaces"
 
 [ui.sidebar.agents.rows_by_agent]
 claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+
+[ui.toast]
+delivery = "system"
+delay_seconds = 1


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- herdr でエージェントの状態が変わったら、macOS の通知を出すようにした
  - 既定では通知が切れていて、他のワークスペースで `blocked` になったエージェントに気づけないため
- herdr のテーマを Tokyo Night にした
  - WezTerm の配色に合わせるため

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- https://herdr.dev/ja/docs/configuration/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
