### PR TITLE
herdrでエージェントを移動するキーバインドを追加

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,6 +1,11 @@
 [theme]
 name = "tokyo-night"
 
+[keys]
+previous_agent = "prefix+shift+k"
+next_agent = "prefix+shift+j"
+focus_agent = "prefix+alt+1..9"
+
 [ui]
 agent_panel_sort = "spaces"
 

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -2,9 +2,12 @@
 name = "tokyo-night"
 
 [keys]
-previous_agent = "prefix+shift+k"
-next_agent = "prefix+shift+j"
-focus_agent = "prefix+alt+1..9"
+previous_tab = ""
+next_tab = ""
+switch_tab = ""
+previous_agent = "prefix+p"
+next_agent = "prefix+n"
+focus_agent = "prefix+1..9"
 
 [ui]
 agent_panel_sort = "spaces"


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- herdr でサイドバーのエージェントを移動するキーバインドを追加した
  - `prefix+p`: 前のエージェントへ移動する
  - `prefix+n`: 次のエージェントへ移動する
  - `prefix+1..9`: 番号でエージェントへ移動する
- 上記と重なるタブのキーバインドを解放した
  - タブを使っておらず、どちらが優先されるかもわからないため

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- https://herdr.dev/ja/docs/configuration/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
