### PR TITLE
権限モードのデフォルトをacceptEditsにする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,7 +49,8 @@
       "Read(id_ed25519)",
       "Read(**/.env)",
       "Read(**/.env.*)"
-    ]
+    ],
+    "defaultMode": "acceptEdits"
   },
   "model": "opus[1m]",
   "statusLine": {


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- Claude Code の権限モードのデフォルトを `acceptEdits` にした。全プロジェクトで、起動時から編集が自動で承認される

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
