### PR TITLE
vimdoc-jaでLazy updateが失敗するのを直す

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -336,26 +336,39 @@ require('lazy').setup({
 
   {
     'vim-jp/vimdoc-ja',
-    -- lazy.nvim runs :helptags after updates, but Neovim rewrites the tracked
-    -- language-specific tag file and then treats the plugin as locally modified.
-    -- Restore the tag file shipped by vimdoc-ja after lazy.nvim regenerates it.
-    build = function(plugin)
-      local result = vim
-        .system({
-          'git',
-          'restore',
-          '--source=HEAD',
-          '--',
-          'doc/tags-ja',
-        }, { cwd = plugin.dir })
-        :wait()
-
-      if result.code ~= 0 then
-        error(result.stderr or 'Failed to restore doc/tags-ja')
-      end
-    end,
-    config = function()
+    config = function(plugin)
       vim.opt.helplang = { 'ja', 'en' }
+
+      -- lazy.nvim runs :helptags after updates, but Neovim rewrites the tracked
+      -- doc/tags-ja shipped by vimdoc-ja and then treats the plugin as locally
+      -- modified. lazy.nvim restores doc/tags on its own, but not the
+      -- language-specific tag file, and it checks for local changes before
+      -- running `build`. So restore the tag file before lazy.nvim starts, while
+      -- the check can still be satisfied.
+      vim.api.nvim_create_autocmd('User', {
+        group = vim.api.nvim_create_augroup('vimdoc_ja_restore_tags', {}),
+        pattern = {
+          'LazyCheckPre',
+          'LazyInstallPre',
+          'LazyRestorePre',
+          'LazyUpdatePre',
+        },
+        callback = function()
+          local result = vim
+            .system({
+              'git',
+              'restore',
+              '--source=HEAD',
+              '--',
+              'doc/tags-ja',
+            }, { cwd = plugin.dir })
+            :wait()
+
+          if result.code ~= 0 then
+            vim.notify(result.stderr or 'Failed to restore doc/tags-ja', vim.log.levels.WARN)
+          end
+        end,
+      })
     end,
   },
 


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- vimdoc-ja の `doc/tags-ja` を復元するタイミングを、`build` フックから `Lazy<Mode>Pre` の autocmd に変えた

`:Lazy update` が次のエラーで失敗するのを直しました。

```
● vimdoc-ja 0.1ms  start
    You have local changes in `/Users/mao.kawaguchi/.local/share/nvim/lazy/vimdoc-ja`:
      * doc/tags-ja
    Please remove them to update.
```

原因は3つが噛み合ったことです。

1. Neovim の `:helptags` が `doc/tags-ja` を書き直し、vimdoc-ja が含めている `!_TAG_FILE_ENCODING utf-8 //` の1行が消える。tracked file なので modified になる
2. lazy.nvim のローカル変更チェックは `doc/tags` だけ自動で復元してくれる。`doc/tags-ja` は対象外
3. update のパイプラインは `git.status` → `git.checkout` → `plugin.docs` → `plugin.build` の順

`build` は最後にしか走らないので、一度 dirty になると `git.status` で止まり、二度と復元されません。lazy.nvim は runner を開始する前に `Lazy<Mode>Pre` を発火するので、そこで復元すればチェックに間に合います。

## やってないこと

- なし

## スクリーンショット/レコード

headless で確認しました。

```
0 initial   : []
1 after tags: [doc/tags-ja ]   ← :helptags で dirty
2 after hook: []               ← LazyUpdatePre で復元
```

## 参考リンク

- https://github.com/folke/lazy.nvim/blob/main/lua/lazy/manage/task/git.lua
- https://github.com/folke/lazy.nvim/blob/main/lua/lazy/manage/init.lua

🤖 Generated with [Claude Code](https://claude.com/claude-code)
