### PR TITLE
vimdoc-jaのhelptags実行をスキップする

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -21,6 +21,20 @@ end
 vim.opt.rtp:prepend(lazypath)
 -- }}}
 
+-- Workarounds {{{
+
+-- Neovim's `:helptags` misreads the C comments in the ASCII art of vimdoc-ja's
+-- usr_08.jax as a tag and fails with `E154: Duplicate tag "/"`. It leaves a
+-- broken doc/tags-ja behind, which makes lazy.nvim treat vimdoc-ja as locally
+-- modified and refuse to update it. vimdoc-ja ships a correct doc/tags-ja, so
+-- skip lazy.nvim's helptags task for it.
+local plugin_task = require('lazy.manage.task.plugin')
+local skip_docs = plugin_task.docs.skip
+plugin_task.docs.skip = function(plugin, opts)
+  return plugin.name == 'vimdoc-ja' or skip_docs(plugin, opts)
+end
+-- }}}
+
 -- Setup {{{
 require('lazy').setup({
   -- Plugin manager {{{
@@ -336,39 +350,8 @@ require('lazy').setup({
 
   {
     'vim-jp/vimdoc-ja',
-    config = function(plugin)
+    config = function()
       vim.opt.helplang = { 'ja', 'en' }
-
-      -- lazy.nvim runs :helptags after updates, but Neovim rewrites the tracked
-      -- doc/tags-ja shipped by vimdoc-ja and then treats the plugin as locally
-      -- modified. lazy.nvim restores doc/tags on its own, but not the
-      -- language-specific tag file, and it checks for local changes before
-      -- running `build`. So restore the tag file before lazy.nvim starts, while
-      -- the check can still be satisfied.
-      vim.api.nvim_create_autocmd('User', {
-        group = vim.api.nvim_create_augroup('vimdoc_ja_restore_tags', {}),
-        pattern = {
-          'LazyCheckPre',
-          'LazyInstallPre',
-          'LazyRestorePre',
-          'LazyUpdatePre',
-        },
-        callback = function()
-          local result = vim
-            .system({
-              'git',
-              'restore',
-              '--source=HEAD',
-              '--',
-              'doc/tags-ja',
-            }, { cwd = plugin.dir })
-            :wait()
-
-          if result.code ~= 0 then
-            vim.notify(result.stderr or 'Failed to restore doc/tags-ja', vim.log.levels.WARN)
-          end
-        end,
-      })
     end,
   },
 


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- lazy.nvim の helptags タスクを vimdoc-ja だけスキップするようにした
  - Neovim の `:helptags` が `usr_08.jax` のアスキーアートにある C コメントをタグと誤認し、`E154: Duplicate tag "/"` で失敗する
  - 壊れた `tags-ja` が残るため、lazy.nvim が vimdoc-ja をローカル変更ありと判断して更新できなくなる
  - vimdoc-ja は正しい `tags-ja` を同梱しているので、helptags は走らせなくてよい
- 前回入れた `tags-ja` の復元処理を削除した
  - `:helptags` が走るたびに再発するため、そもそも直っていなかった

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
